### PR TITLE
Feature/night mode

### DIFF
--- a/mobile/src/main/java/org/inventivetalent/trashapp/SettingsActivity.java
+++ b/mobile/src/main/java/org/inventivetalent/trashapp/SettingsActivity.java
@@ -3,6 +3,7 @@ package org.inventivetalent.trashapp;
 import android.app.AlertDialog;
 import android.content.DialogInterface;
 import android.content.Intent;
+import android.content.SharedPreferences;
 import android.content.pm.PackageManager;
 import android.net.Uri;
 import android.os.AsyncTask;
@@ -12,7 +13,6 @@ import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.widget.Toast;
-
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.app.AppCompatActivity;
@@ -21,16 +21,17 @@ import androidx.preference.Preference;
 import androidx.preference.PreferenceCategory;
 import androidx.preference.PreferenceFragmentCompat;
 import androidx.preference.PreferenceGroup;
+import androidx.preference.PreferenceManager;
 import androidx.preference.PreferenceScreen;
+import androidx.preference.SwitchPreference;
 import androidx.preference.TwoStatePreference;
-
 import com.google.android.material.snackbar.Snackbar;
 import com.google.firebase.analytics.FirebaseAnalytics;
-
 import org.inventivetalent.trashapp.common.BillingConstants;
 import org.inventivetalent.trashapp.common.PaymentHandler;
 import org.inventivetalent.trashapp.common.PaymentReadyListener;
 import org.inventivetalent.trashapp.common.Util;
+import org.inventivetalent.trashapp.ui.main.MapFragment;
 
 public class SettingsActivity extends AppCompatActivity implements PreferenceFragmentCompat.OnPreferenceStartFragmentCallback {
 
@@ -170,6 +171,20 @@ public class SettingsActivity extends AppCompatActivity implements PreferenceFra
 				});
 			}
 
+			final SwitchPreference nightModePreference = findPreference("night_mode");
+			if (nightModePreference != null) {
+				nightModePreference.setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener() {
+					@Override
+					public boolean onPreferenceChange(Preference preference, Object newValue) {
+						boolean nightMode = Boolean.valueOf( String.valueOf(newValue) );
+						SharedPreferences sharedPreferences = PreferenceManager.getDefaultSharedPreferences(TabActivity.instance);
+						sharedPreferences.edit().putBoolean("night_mode", nightMode).apply();
+						MapFragment.instance.setNightMode(nightMode);
+						return true;
+					}
+				});
+			}
+
 			final Preference unlockThemesPreference = findPreference("dummy_unlock_themes");
 			if (unlockThemesPreference != null) {
 				unlockThemesPreference.setOnPreferenceClickListener(new Preference.OnPreferenceClickListener() {
@@ -228,6 +243,7 @@ public class SettingsActivity extends AppCompatActivity implements PreferenceFra
 						if (themePreference != null) { themePreference.setEnabled(hasThemes || hasPremium); }
 
 						if (unlockThemesPreference != null) { unlockThemesPreference.setVisible(!hasThemes && !hasPremium); }
+						if (nightModePreference != null) { nightModePreference.setEnabled(hasThemes || hasPremium); }
 
 						if (mFirebaseAnalytics != null) {
 							mFirebaseAnalytics.setUserProperty("sku_themes", String.valueOf(hasPremium));

--- a/mobile/src/main/java/org/inventivetalent/trashapp/ui/main/MapFragment.java
+++ b/mobile/src/main/java/org/inventivetalent/trashapp/ui/main/MapFragment.java
@@ -3,6 +3,7 @@ package org.inventivetalent.trashapp.ui.main;
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
+import android.graphics.Color;
 import android.graphics.PorterDuff;
 import android.graphics.drawable.Drawable;
 import android.location.Location;
@@ -40,6 +41,7 @@ import org.osmdroid.views.MapView;
 import org.osmdroid.views.overlay.CopyrightOverlay;
 import org.osmdroid.views.overlay.Marker;
 import org.osmdroid.views.overlay.Polyline;
+import org.osmdroid.views.overlay.TilesOverlay;
 import org.osmdroid.views.overlay.gestures.RotationGestureOverlay;
 
 import java.util.Arrays;
@@ -61,6 +63,8 @@ public class MapFragment extends Fragment {
 							| TileSourcePolicy.FLAG_USER_AGENT_NORMALIZED
 			));
 
+	public static MapFragment instance;
+
 	private FirebaseAnalytics mFirebaseAnalytics;
 	private boolean           debug;
 
@@ -74,6 +78,7 @@ public class MapFragment extends Fragment {
 	//	private Marker    lastMarker;
 
 	private boolean zoomedToSelf = false;
+	private boolean nightMode = false;
 
 	private Marker      selfMarker;
 	private Marker      searchCenterMarker;
@@ -90,6 +95,7 @@ public class MapFragment extends Fragment {
 
 	public MapFragment() {
 		// Required empty public constructor
+		instance = this;
 	}
 
 	@Override
@@ -100,7 +106,7 @@ public class MapFragment extends Fragment {
 
 		sharedPreferences = PreferenceManager.getDefaultSharedPreferences(getActivity());
 		debug = Util.getBoolean(sharedPreferences, "enable_debug", false);
-
+		nightMode = Util.getBoolean(sharedPreferences, "night_mode", false);
 		mFirebaseAnalytics = FirebaseAnalytics.getInstance(getActivity());
 	}
 
@@ -263,6 +269,9 @@ public class MapFragment extends Fragment {
 				polyline.setWidth(5f);
 				polyline.setInfoWindow(null);
 				mapView.getOverlays().add(polyline);
+
+				// Apply night_mode preference (only once!)
+				setNightMode(nightMode);
 			}
 
 			//				MarkerOptions markerOptions = new MarkerOptions()
@@ -407,6 +416,18 @@ public class MapFragment extends Fragment {
 	//		moveMap(lastKnownLocation);
 	//		setMarkers(closestTrashCan);
 	//	}
+
+	public void setNightMode(boolean state) {
+		if (state)	{
+			mapView.getOverlayManager().getTilesOverlay().setColorFilter(TilesOverlay.INVERT_COLORS);
+			selfMarker.getIcon().setColorFilter(Color.WHITE, PorterDuff.Mode.SRC_IN);
+			polyline.setColor(Color.WHITE);
+		} else {
+			mapView.getOverlayManager().getTilesOverlay().setColorFilter(null);
+			selfMarker.getIcon().setColorFilter(null);
+			polyline.setColor(Color.BLACK);
+		}
+	}
 
 	@Override
 	public void onAttach(Context context) {

--- a/mobile/src/main/res/xml/root_preferences.xml
+++ b/mobile/src/main/res/xml/root_preferences.xml
@@ -52,6 +52,10 @@
                 android:enabled="true"
                 android:key="app_theme"/>
 
+        <SwitchPreference android:title="@string/settings_night_mode"
+            android:defaultValue="false"
+            android:key="night_mode"/>
+
         <Preference android:title="@string/unlock_themes"
                 android:key="dummy_unlock_themes"/>
 

--- a/trashapp_common/src/main/res/values/strings.xml
+++ b/trashapp_common/src/main/res/values/strings.xml
@@ -163,4 +163,5 @@
     <string name="confirm">Confirm</string>
     <string name="osm_auth_title">OpenStreetMap Authentication</string>
     <string name="unlock_themes">Get more Themes!</string>
+    <string name="settings_night_mode">Night mode</string>
 </resources>


### PR DESCRIPTION
I've added a new option called `Night mode` that inverts the colors of the map, the self-marker as well as the polyline. The setting is available under the premium-category. I've also tested the premium check using some debug lines, but it should work with the premium-check without a problem.

Here are two screenshots:

The new setting:
![](http://sc.m4taiori.de/Screenshot_20190917_221736_org.inventivetalent.trashapp.jpg)

When night-mode is activated:
![](http://sc.m4taiori.de/Screenshot_20190917_222817_org.inventivetalent.trashapp.jpg)