### PR TITLE
Feature/theme/pumpkin

### DIFF
--- a/trashapp_common/src/main/java/org/inventivetalent/trashapp/common/Util.java
+++ b/trashapp_common/src/main/java/org/inventivetalent/trashapp/common/Util.java
@@ -273,6 +273,9 @@ public class Util {
 			case "dark_grass":
 				rId = R.style.DarkGrassTheme;
 				break;
+			case "pumpkin":
+				rId = R.style.PumpkinTheme;
+				break;
 			case "grass":
 			default:
 				rId = R.style.GrassTheme;

--- a/trashapp_common/src/main/res/values/arrays.xml
+++ b/trashapp_common/src/main/res/values/arrays.xml
@@ -3,11 +3,13 @@
         <item>@string/theme_grass</item>
         <item>@string/theme_dark_grass</item>
         <item>@string/theme_classic</item>
+        <item>@string/theme_pumpkin</item>
     </string-array>
     <string-array name="theme_values">
         <item>grass</item>
         <item>dark_grass</item>
         <item>classic</item>
+        <item>pumpkin</item>
     </string-array>
 
 

--- a/trashapp_common/src/main/res/values/colors.xml
+++ b/trashapp_common/src/main/res/values/colors.xml
@@ -19,6 +19,11 @@
     <color name="darkBackground">#222</color>
     <color name="darkBackgroundLight">#323232</color>
 
+    <!-- pumpkin -->
+    <color name="pumpkinPrimary">#616161</color>
+    <color name="pumpkinPrimaryDark">#222</color>
+    <color name="pumpkinSecondary">#FB8C00</color>
+    <color name="pumpkinSecondaryDark">#FF6F00</color>
 
     <color name="primaryTextColor">#000</color>
     <color name="secondaryTextColor">#fff</color>

--- a/trashapp_common/src/main/res/values/strings.xml
+++ b/trashapp_common/src/main/res/values/strings.xml
@@ -167,6 +167,7 @@
     <string name="theme_grass">Grass</string>
     <string name="theme_dark_grass">Dark Grass</string>
     <string name="theme_classic">Classic</string>
+    <string name="theme_pumpkin">Pumpkin</string>
     <string name="general">General</string>
     <string name="waste">Waste</string>
     <string name="none">None</string>

--- a/trashapp_common/src/main/res/values/styles.xml
+++ b/trashapp_common/src/main/res/values/styles.xml
@@ -29,6 +29,20 @@
         <item name="alertDialogTheme">@style/Theme.AppCompat.Dialog</item><!-- no idea why this just makes it dark... -->
         <item name="dialogTheme">@style/Theme.AppCompat.Dialog</item><!-- TODO: the default dialog (e.g. clear cache confirm) still appears light -->
     </style>
+    <style name="PumpkinTheme" parent="AppTheme">
+        <item name="colorPrimary">@color/pumpkinPrimary</item>
+        <item name="colorPrimaryDark">@color/pumpkinPrimaryDark</item>
+        <item name="colorAccent">@color/pumpkinSecondaryDark</item>
+        <item name="android:colorBackground">@color/darkBackground</item>
+        <item name="android:textColor">@color/primary_text_color_selector_dark</item>
+        <item name="colorButtonNormal">@color/darkBackgroundLight</item>
+        <item name="android:popupBackground">@color/darkBackgroundLight</item>
+        <item name="android:itemBackground">@color/darkBackgroundLight</item>
+        <item name="titleTextColor">@color/primaryTextColorDark</item>
+        <item name="actionMenuTextColor">@color/primaryTextColorDark</item>
+        <item name="alertDialogTheme">@style/Theme.AppCompat.Dialog</item><!-- no idea why this just makes it dark... -->
+        <item name="dialogTheme">@style/Theme.AppCompat.Dialog</item><!-- TODO: the default dialog (e.g. clear cache confirm) still appears light -->
+    </style>
 
     <style name="AppTheme.NoActionBar">
         <item name="windowActionBar">false</item>

--- a/trashapp_common/src/main/res/values/styles.xml
+++ b/trashapp_common/src/main/res/values/styles.xml
@@ -29,19 +29,10 @@
         <item name="alertDialogTheme">@style/Theme.AppCompat.Dialog</item><!-- no idea why this just makes it dark... -->
         <item name="dialogTheme">@style/Theme.AppCompat.Dialog</item><!-- TODO: the default dialog (e.g. clear cache confirm) still appears light -->
     </style>
-    <style name="PumpkinTheme" parent="AppTheme">
+    <style name="PumpkinTheme" parent="DarkGrassTheme">
         <item name="colorPrimary">@color/pumpkinPrimary</item>
         <item name="colorPrimaryDark">@color/pumpkinPrimaryDark</item>
         <item name="colorAccent">@color/pumpkinSecondaryDark</item>
-        <item name="android:colorBackground">@color/darkBackground</item>
-        <item name="android:textColor">@color/primary_text_color_selector_dark</item>
-        <item name="colorButtonNormal">@color/darkBackgroundLight</item>
-        <item name="android:popupBackground">@color/darkBackgroundLight</item>
-        <item name="android:itemBackground">@color/darkBackgroundLight</item>
-        <item name="titleTextColor">@color/primaryTextColorDark</item>
-        <item name="actionMenuTextColor">@color/primaryTextColorDark</item>
-        <item name="alertDialogTheme">@style/Theme.AppCompat.Dialog</item><!-- no idea why this just makes it dark... -->
-        <item name="dialogTheme">@style/Theme.AppCompat.Dialog</item><!-- TODO: the default dialog (e.g. clear cache confirm) still appears light -->
     </style>
 
     <style name="AppTheme.NoActionBar">


### PR DESCRIPTION
- Added a tiny little theme with a dark and orange look to add a bit of halloween flare 😎 
- **IMPORTANT** I've tested everything multiple times on my device. However, the theme selection always gets discarded whenever I change the theme (including existing themes). I suspect [line 283](https://github.com/InventivetalentDev/TrashApp/blob/67ac6746ddd24ac2b4548a69b526f1db5a531954/trashapp_common/src/main/java/org/inventivetalent/trashapp/common/Util.java#L283) to cause this little problem because I used dummy-keys, so I would recommend testing it yourself with your api-tokens to ensure it isn't discarded under prod.-like conditions 🙂 

As always here's a tiny preview:

_Map in normal mode_:
![Screenshot_20191023_230318_org inventivetalent trashapp](https://user-images.githubusercontent.com/8280615/67434045-9d7e5c80-f5e9-11e9-9334-13499c8b5297.jpg)

_Map in night-mode_:
![Screenshot_20191023_222816_org inventivetalent trashapp](https://user-images.githubusercontent.com/8280615/67434047-9e16f300-f5e9-11e9-848d-769f5fc672db.jpg)

_Compass_:
![Screenshot_20191023_222744_org inventivetalent trashapp](https://user-images.githubusercontent.com/8280615/67434046-9e16f300-f5e9-11e9-9267-ac133200151b.jpg)

_Settings_:
![Screenshot_20191023_222836_org inventivetalent trashapp](https://user-images.githubusercontent.com/8280615/67434048-9e16f300-f5e9-11e9-93d3-2f90b3390ee4.jpg)
