### PR TITLE
Fix NPE when toggling night mode before map overlays exist

### DIFF
--- a/mobile/src/main/java/org/inventivetalent/trashapp/SettingsActivity.java
+++ b/mobile/src/main/java/org/inventivetalent/trashapp/SettingsActivity.java
@@ -163,7 +163,9 @@ public class SettingsActivity extends AppCompatActivity implements PreferenceFra
 						boolean nightMode = Boolean.valueOf(String.valueOf(newValue));
 						SharedPreferences sharedPreferences = PreferenceManager.getDefaultSharedPreferences(TabActivity.instance);
 						sharedPreferences.edit().putBoolean("night_mode", nightMode).apply();
-						MapFragment.instance.setNightMode(nightMode);
+						if (MapFragment.instance != null) {
+							MapFragment.instance.setNightMode(nightMode);
+						}
 						return true;
 					}
 				});

--- a/mobile/src/main/java/org/inventivetalent/trashapp/ui/main/MapFragment.java
+++ b/mobile/src/main/java/org/inventivetalent/trashapp/ui/main/MapFragment.java
@@ -403,16 +403,27 @@ public class MapFragment extends Fragment {
 	//	}
 
 	public void setNightMode(boolean state) {
-		if (state)	{
-			mapView.getOverlayManager().getTilesOverlay().setColorFilter(TilesOverlay.INVERT_COLORS);
-			selfMarker.getIcon().setColorFilter(Color.WHITE, PorterDuff.Mode.SRC_IN);
-			polyline.setColor(Color.WHITE);
-			copyrightOverlay.setTextColor(Color.WHITE);
-		} else {
-			mapView.getOverlayManager().getTilesOverlay().setColorFilter(null);
-			selfMarker.getIcon().setColorFilter(null);
-			polyline.setColor(Color.BLACK);
-			copyrightOverlay.setTextColor(Color.BLACK);
+		// remember the state, so it can be applied later to overlays that don't exist yet
+		// (selfMarker & polyline are only created once a location fix arrives)
+		nightMode = state;
+		if (mapView != null) {
+			mapView.getOverlayManager().getTilesOverlay().setColorFilter(state ? TilesOverlay.INVERT_COLORS : null);
+		}
+		if (selfMarker != null && selfMarker.getIcon() != null) {
+			if (state) {
+				selfMarker.getIcon().setColorFilter(Color.WHITE, PorterDuff.Mode.SRC_IN);
+			} else {
+				selfMarker.getIcon().setColorFilter(null);
+			}
+		}
+		if (polyline != null) {
+			polyline.setColor(state ? Color.WHITE : Color.BLACK);
+		}
+		if (copyrightOverlay != null) {
+			copyrightOverlay.setTextColor(state ? Color.WHITE : Color.BLACK);
+		}
+		if (mapView != null) {
+			mapView.invalidate();
 		}
 	}
 


### PR DESCRIPTION
Crashlytics issue 4815c7b4ef595d2df780f8c4aaf08c70:
NullPointerException in MapFragment.setNightMode via the night_mode
preference change listener. selfMarker and polyline are only created
once a location fix arrives (updateSelfMarker), so toggling the
night mode switch before that dereferenced a null marker.

- Null-guard mapView, selfMarker (and its icon), polyline and
  copyrightOverlay in setNightMode
- Store the requested state in the nightMode field so it is applied
  once the overlays are created
- Guard against a null MapFragment.instance in SettingsActivity
- Invalidate the map after applying so the change shows immediately

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01TY6ht2nFr4te6QNvj4Scs1